### PR TITLE
Dismiss ntfy notifications after user responds or timeout

### DIFF
--- a/bin/cli.mjs
+++ b/bin/cli.mjs
@@ -195,7 +195,7 @@ if (isMain) {
   const { loadConfig, saveConfig, generateTopic, resolveAuth } = await import(
     "../src/config.mjs"
   );
-  const { sendNotification, waitForResponse, formatToolInfo } = await import(
+  const { sendNotification, deleteNotification, waitForResponse, formatToolInfo } = await import(
     "../src/ntfy.mjs"
   );
   const { processHook } = await import("../src/hook.mjs");
@@ -218,6 +218,7 @@ if (isMain) {
     generateTopic,
     resolveAuth,
     sendNotification,
+    deleteNotification,
     waitForResponse,
     formatToolInfo,
     processHook,

--- a/src/hook.mjs
+++ b/src/hook.mjs
@@ -137,6 +137,7 @@ export async function processAskUserQuestion(input, deps) {
       batches.push(options.slice(j, j + MAX_BUTTONS));
     }
 
+    const messageIds = [];
     for (let i = 0; i < batches.length; i++) {
       const batch = batches[i];
       const batchInfo = batches.length > 1 ? `(${i + 1}/${batches.length})` : undefined;
@@ -153,6 +154,7 @@ export async function processAskUserQuestion(input, deps) {
         ...(auth && { auth }),
       });
       if (!sent) return ASK;
+      if (sent?.messageId) messageIds.push(sent.messageId);
     }
 
     // AskUserQuestion uses standard timeout (not planTimeout)
@@ -168,6 +170,16 @@ export async function processAskUserQuestion(input, deps) {
     } catch (err) {
       console.error("[claude-remote-approver] Response listener failed:", err.message, "— Falling back to CLI.");
       return ASK;
+    }
+
+    if (deps.deleteNotification) {
+      for (const msgId of messageIds) {
+        try {
+          await deps.deleteNotification({ server: config.ntfyServer, topic: config.topic, messageId: msgId, ...(auth && { auth }) });
+        } catch (err) {
+          console.warn("[claude-remote-approver] Failed to dismiss notification:", err.message);
+        }
+      }
     }
 
     if (response.answer) {
@@ -203,7 +215,7 @@ export async function processAskUserQuestion(input, deps) {
  * @param {Function} deps.formatToolInfo
  * @returns {Promise<object>} Decision JSON
  */
-export async function processHook(input, { loadConfig, sendNotification, waitForResponse, formatToolInfo, resolveAuth }) {
+export async function processHook(input, { loadConfig, sendNotification, deleteNotification, waitForResponse, formatToolInfo, resolveAuth }) {
   const config = loadConfig();
 
   if (!config.topic) {
@@ -213,7 +225,7 @@ export async function processHook(input, { loadConfig, sendNotification, waitFor
   const auth = resolveAuth ? resolveAuth(config) : null;
 
   if (isAskUserQuestion(input)) {
-    return processAskUserQuestion(input, { loadConfig, sendNotification, waitForResponse, resolveAuth });
+    return processAskUserQuestion(input, { loadConfig, sendNotification, deleteNotification, waitForResponse, resolveAuth });
   }
 
   const requestId = crypto.randomUUID();
@@ -234,6 +246,8 @@ export async function processHook(input, { loadConfig, sendNotification, waitFor
   });
   if (!sent) return ASK;
 
+  const messageId = sent?.messageId;
+
   let response;
   try {
     const isPlanReview = input.tool_name === "ExitPlanMode";
@@ -248,6 +262,14 @@ export async function processHook(input, { loadConfig, sendNotification, waitFor
   } catch (err) {
     console.error("[claude-remote-approver] Response listener failed:", err.message, "— Falling back to CLI.");
     return ASK;
+  }
+
+  if (messageId && deleteNotification) {
+    try {
+      await deleteNotification({ server: config.ntfyServer, topic: config.topic, messageId, ...(auth && { auth }) });
+    } catch (err) {
+      console.warn("[claude-remote-approver] Failed to dismiss notification:", err.message);
+    }
   }
 
   if (response.timeout) {

--- a/src/ntfy.mjs
+++ b/src/ntfy.mjs
@@ -25,7 +25,34 @@ export async function sendNotification({ server, topic, title, message, actions,
     throw new Error(`ntfy notification failed: HTTP ${response.status}`);
   }
 
-  return response;
+  let messageId;
+  try {
+    const body = await response.json();
+    messageId = body.id;
+  } catch {
+    // ignore parse errors
+  }
+
+  return { messageId };
+}
+
+/**
+ * Delete a notification from ntfy server cache.
+ *
+ * @param {{ server: string, topic: string, messageId: string, auth?: { username: string, password: string } }} params
+ */
+export async function deleteNotification({ server, topic, messageId, auth }) {
+  const baseUrl = server.replace(/\/+$/, '');
+  const url = `${baseUrl}/${topic}/${messageId}`;
+
+  const response = await fetch(url, {
+    method: 'DELETE',
+    headers: buildAuthHeader(auth),
+  });
+
+  if (!response.ok) {
+    throw new Error(`ntfy delete failed: HTTP ${response.status}`);
+  }
 }
 
 /**

--- a/test/hook.test.mjs
+++ b/test/hook.test.mjs
@@ -210,7 +210,8 @@ describe("processHook", () => {
 
     return {
       loadConfig: mock.fn(() => overrides.config ?? defaultConfig),
-      sendNotification: mock.fn(async () => ({ ok: true, status: 200 })),
+      sendNotification: mock.fn(async () => ({ messageId: "msg-001" })),
+      deleteNotification: mock.fn(async () => {}),
       waitForResponse: mock.fn(
         async () => overrides.waitResult ?? { approved: true }
       ),
@@ -848,6 +849,67 @@ describe("processHook", () => {
     }
   });
 
+  // ==================== deleteNotification ====================
+
+  it("should call deleteNotification with messageId after response", async () => {
+    const deps = createDeps({ waitResult: { approved: true } });
+
+    await processHook(sampleInput, deps);
+
+    assert.equal(deps.deleteNotification.mock.callCount(), 1);
+    const callArgs = deps.deleteNotification.mock.calls[0].arguments[0];
+    assert.equal(callArgs.server, "https://ntfy.sh");
+    assert.equal(callArgs.topic, "test-topic");
+    assert.equal(callArgs.messageId, "msg-001");
+  });
+
+  it("should pass auth to deleteNotification when resolveAuth returns credentials", async () => {
+    const auth = { username: "myuser", password: "mypass" };
+    const deps = createDeps({ waitResult: { approved: true } });
+    deps.resolveAuth = mock.fn(() => auth);
+
+    await processHook(sampleInput, deps);
+
+    assert.equal(deps.deleteNotification.mock.callCount(), 1);
+    const callArgs = deps.deleteNotification.mock.calls[0].arguments[0];
+    assert.deepEqual(callArgs.auth, auth);
+  });
+
+  it("should not call deleteNotification when messageId is undefined", async () => {
+    const deps = createDeps({ waitResult: { approved: true } });
+    deps.sendNotification = mock.fn(async () => ({ messageId: undefined }));
+
+    await processHook(sampleInput, deps);
+
+    assert.equal(deps.deleteNotification.mock.callCount(), 0);
+  });
+
+  it("should not fail when deleteNotification throws", async () => {
+    const deps = createDeps({ waitResult: { approved: true } });
+    deps.deleteNotification = mock.fn(async () => { throw new Error("delete failed"); });
+
+    const result = await processHook(sampleInput, deps);
+
+    assert.deepEqual(result, {
+      hookSpecificOutput: {
+        hookEventName: "PermissionRequest",
+        decision: { behavior: "allow" },
+      },
+    });
+  });
+
+  it("should still call deleteNotification when response times out", async () => {
+    const deps = createDeps({ waitResult: { timeout: true } });
+    const errorSpy = mock.method(console, "error", () => {});
+    try {
+      await processHook(sampleInput, deps);
+    } finally {
+      errorSpy.mock.restore();
+    }
+
+    assert.equal(deps.deleteNotification.mock.callCount(), 1, "should still attempt to dismiss the notification on timeout");
+  });
+
   it("should work without auth when resolveAuth returns null", async () => {
     const deps = createDeps();
     deps.resolveAuth = mock.fn(() => null);
@@ -1400,6 +1462,162 @@ describe("processAskUserQuestion", () => {
       errorSpy.mock.restore();
       _internal.delay = originalDelay;
     }
+  });
+
+  // ==================== deleteNotification ====================
+
+  it("should call deleteNotification with collected messageIds after response", async () => {
+    const input = {
+      tool_name: "AskUserQuestion",
+      tool_input: {
+        questions: [{
+          question: "Which?",
+          header: "Q",
+          options: [{ label: "A", description: "a" }, { label: "B", description: "b" }],
+          multiSelect: false,
+        }],
+      },
+    };
+    const deps = {
+      loadConfig: mock.fn(() => ({
+        topic: "test-topic",
+        ntfyServer: "https://ntfy.sh",
+        timeout: 120,
+      })),
+      sendNotification: mock.fn(async () => ({ messageId: "msg-q1" })),
+      deleteNotification: mock.fn(async () => {}),
+      waitForResponse: mock.fn(async () => ({ answer: "A" })),
+    };
+
+    await processAskUserQuestion(input, deps);
+
+    assert.equal(deps.deleteNotification.mock.callCount(), 1);
+    const callArgs = deps.deleteNotification.mock.calls[0].arguments[0];
+    assert.equal(callArgs.messageId, "msg-q1");
+    assert.equal(callArgs.server, "https://ntfy.sh");
+    assert.equal(callArgs.topic, "test-topic");
+  });
+
+  it("should delete all batch messageIds for multi-batch questions", async () => {
+    const input = {
+      tool_name: "AskUserQuestion",
+      tool_input: {
+        questions: [{
+          question: "Pick one",
+          header: "Q",
+          options: [
+            { label: "A", description: "a" },
+            { label: "B", description: "b" },
+            { label: "C", description: "c" },
+            { label: "D", description: "d" },
+          ],
+          multiSelect: false,
+        }],
+      },
+    };
+    let callCount = 0;
+    const deps = {
+      loadConfig: mock.fn(() => ({
+        topic: "test-topic",
+        ntfyServer: "https://ntfy.sh",
+        timeout: 120,
+      })),
+      sendNotification: mock.fn(async () => {
+        callCount++;
+        return { messageId: `msg-batch-${callCount}` };
+      }),
+      deleteNotification: mock.fn(async () => {}),
+      waitForResponse: mock.fn(async () => ({ answer: "C" })),
+    };
+
+    await processAskUserQuestion(input, deps);
+
+    assert.equal(deps.deleteNotification.mock.callCount(), 2);
+    assert.equal(deps.deleteNotification.mock.calls[0].arguments[0].messageId, "msg-batch-1");
+    assert.equal(deps.deleteNotification.mock.calls[1].arguments[0].messageId, "msg-batch-2");
+  });
+
+  it("should not fail when deleteNotification throws in processAskUserQuestion", async () => {
+    const input = {
+      tool_name: "AskUserQuestion",
+      tool_input: {
+        questions: [{
+          question: "Which?",
+          header: "Q",
+          options: [{ label: "A", description: "a" }],
+          multiSelect: false,
+        }],
+      },
+    };
+    const deps = {
+      loadConfig: mock.fn(() => ({
+        topic: "test-topic",
+        ntfyServer: "https://ntfy.sh",
+        timeout: 120,
+      })),
+      sendNotification: mock.fn(async () => ({ messageId: "msg-x" })),
+      deleteNotification: mock.fn(async () => { throw new Error("delete failed"); }),
+      waitForResponse: mock.fn(async () => ({ answer: "A" })),
+    };
+
+    const result = await processAskUserQuestion(input, deps);
+
+    assert.equal(result.hookSpecificOutput.decision.behavior, "allow");
+  });
+
+  it("should skip deleteNotification when messageId is missing from sendNotification response", async () => {
+    const input = {
+      tool_name: "AskUserQuestion",
+      tool_input: {
+        questions: [{
+          question: "Which?",
+          header: "Q",
+          options: [{ label: "A", description: "a" }],
+          multiSelect: false,
+        }],
+      },
+    };
+    const deps = {
+      loadConfig: mock.fn(() => ({
+        topic: "test-topic",
+        ntfyServer: "https://ntfy.sh",
+        timeout: 120,
+      })),
+      sendNotification: mock.fn(async () => ({})),
+      deleteNotification: mock.fn(async () => {}),
+      waitForResponse: mock.fn(async () => ({ answer: "A" })),
+    };
+
+    await processAskUserQuestion(input, deps);
+
+    assert.equal(deps.deleteNotification.mock.callCount(), 0);
+  });
+
+  it("should still work when deleteNotification is not provided", async () => {
+    const input = {
+      tool_name: "AskUserQuestion",
+      tool_input: {
+        questions: [{
+          question: "Which?",
+          header: "Q",
+          options: [{ label: "A", description: "a" }],
+          multiSelect: false,
+        }],
+      },
+    };
+    const deps = {
+      loadConfig: mock.fn(() => ({
+        topic: "test-topic",
+        ntfyServer: "https://ntfy.sh",
+        timeout: 120,
+      })),
+      sendNotification: mock.fn(async () => ({ messageId: "msg-y" })),
+      waitForResponse: mock.fn(async () => ({ answer: "A" })),
+    };
+
+    const result = await processAskUserQuestion(input, deps);
+
+    assert.equal(result.hookSpecificOutput.decision.behavior, "allow");
   });
 
   // ==================== Auth threading (Basic Auth) ====================

--- a/test/ntfy.test.mjs
+++ b/test/ntfy.test.mjs
@@ -11,7 +11,7 @@
 
 import { describe, it, beforeEach, afterEach, mock } from "node:test";
 import assert from "node:assert/strict";
-import { sendNotification, waitForResponse, formatToolInfo, stripMarkdown, buildAuthHeader } from "../src/ntfy.mjs";
+import { sendNotification, deleteNotification, waitForResponse, formatToolInfo, stripMarkdown, buildAuthHeader } from "../src/ntfy.mjs";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -261,8 +261,8 @@ describe("sendNotification", () => {
       requestId: "req-007",
     });
 
-    assert.ok(result, "should return a response object");
-    assert.equal(result.status, 200);
+    assert.ok(result, "should return a result object");
+    assert.equal(result.messageId, "abc123");
   });
 
   it("should throw when fetch returns non-ok status", async () => {
@@ -349,6 +349,98 @@ describe("sendNotification", () => {
       headers.Authorization,
       undefined,
       "Authorization header should not be present when auth is not provided"
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// deleteNotification
+// ---------------------------------------------------------------------------
+
+describe("deleteNotification", () => {
+  let originalFetch;
+  beforeEach(() => { originalFetch = globalThis.fetch; });
+  afterEach(() => { globalThis.fetch = originalFetch; });
+
+  it("should be a function exported from the module", () => {
+    assert.equal(typeof deleteNotification, "function");
+  });
+
+  it("should send DELETE to {server}/{topic}/{messageId}", async () => {
+    const mockFetch = createMockFetch({}, 200);
+    globalThis.fetch = mockFetch;
+
+    await deleteNotification({
+      server: "https://ntfy.sh",
+      topic: "test-topic",
+      messageId: "msg-123",
+    });
+
+    assert.equal(mockFetch.calls.length, 1);
+    assert.equal(mockFetch.calls[0].url, "https://ntfy.sh/test-topic/msg-123");
+    assert.equal(mockFetch.calls[0].options.method, "DELETE");
+  });
+
+  it("should strip trailing slash from server URL", async () => {
+    const mockFetch = createMockFetch({}, 200);
+    globalThis.fetch = mockFetch;
+
+    await deleteNotification({
+      server: "https://ntfy.sh/",
+      topic: "my-topic",
+      messageId: "msg-456",
+    });
+
+    assert.equal(mockFetch.calls[0].url, "https://ntfy.sh/my-topic/msg-456");
+  });
+
+  it("should include Authorization header when auth is provided", async () => {
+    const mockFetch = createMockFetch({}, 200);
+    globalThis.fetch = mockFetch;
+
+    await deleteNotification({
+      server: "https://ntfy.sh",
+      topic: "test-topic",
+      messageId: "msg-auth",
+      auth: { username: "myuser", password: "mypass" },
+    });
+
+    const headers = mockFetch.calls[0].options.headers;
+    assert.equal(
+      headers.Authorization,
+      `Basic ${btoa("myuser:mypass")}`,
+    );
+  });
+
+  it("should NOT include Authorization header when auth is not provided", async () => {
+    const mockFetch = createMockFetch({}, 200);
+    globalThis.fetch = mockFetch;
+
+    await deleteNotification({
+      server: "https://ntfy.sh",
+      topic: "test-topic",
+      messageId: "msg-noauth",
+    });
+
+    const headers = mockFetch.calls[0].options.headers;
+    assert.equal(headers.Authorization, undefined);
+  });
+
+  it("should throw when fetch returns non-ok status", async () => {
+    const mockFetch = createMockFetch({}, 404);
+    globalThis.fetch = mockFetch;
+
+    await assert.rejects(
+      () => deleteNotification({
+        server: "https://ntfy.sh",
+        topic: "test-topic",
+        messageId: "msg-gone",
+      }),
+      (err) => {
+        assert.ok(err instanceof Error);
+        assert.ok(err.message.includes("HTTP 404"));
+        return true;
+      }
     );
   });
 });


### PR DESCRIPTION
After a user approves, denies, or the request times out, the notification is no longer actionable. Delete it from the ntfy cache to keep the notification list clean.

- Add deleteNotification() to ntfy.mjs
- sendNotification now returns { messageId } parsed from response
- processHook and processAskUserQuestion delete notifications after receiving a response (best-effort, failures logged as warn)
- Add 16 tests covering delete behavior and edge cases