### PR TITLE
Support title config

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,7 @@ Config file location: `~/.claude-remote-approver.json`
 | `autoDeny` | `string[]` | `[]` | Reserved for future use. |
 | `ntfyUsername` | `string` | `""` | Username for ntfy Basic Auth. Set this if your ntfy server requires authentication. |
 | `ntfyPassword` | `string` | `""` | Password for ntfy Basic Auth. Set this if your ntfy server requires authentication. |
+| `title` | `string` | `"Claude Code"` | Custom prefix for notification titles. Useful for distinguishing multiple instances (e.g. `"Claude (work)"`, `"Claude (personal)"`). |
 
 ### Using a self-hosted ntfy server
 

--- a/bin/cli.mjs
+++ b/bin/cli.mjs
@@ -82,6 +82,7 @@ export async function main(args, deps) {
 
     case "status": {
       const config = deps.loadConfig();
+      deps.stdout.write(`Title:   ${config.title}\n`);
       deps.stdout.write(`Topic:   ${config.topic}\n`);
       deps.stdout.write(`Server:  ${config.ntfyServer}\n`);
       deps.stdout.write(`Timeout: ${config.timeout}s\n`);

--- a/src/config.mjs
+++ b/src/config.mjs
@@ -15,6 +15,7 @@ export const DEFAULT_CONFIG = {
   autoDeny: [],
   ntfyUsername: "",
   ntfyPassword: "",
+  title: "Claude Code",
 };
 
 export function loadConfig(configPath = CONFIG_PATH) {
@@ -30,6 +31,7 @@ export function loadConfig(configPath = CONFIG_PATH) {
     if (!Array.isArray(config.autoDeny)) config.autoDeny = DEFAULT_CONFIG.autoDeny;
     if (typeof config.ntfyUsername !== "string") config.ntfyUsername = DEFAULT_CONFIG.ntfyUsername;
     if (typeof config.ntfyPassword !== "string") config.ntfyPassword = DEFAULT_CONFIG.ntfyPassword;
+    if (typeof config.title !== "string" || !config.title) config.title = DEFAULT_CONFIG.title;
     return config;
   } catch (err) {
     if (err.code === "ENOENT") {

--- a/src/hook.mjs
+++ b/src/hook.mjs
@@ -124,6 +124,7 @@ export async function processAskUserQuestion(input, deps) {
   if (!config.topic) return ASK;
 
   const auth = deps.resolveAuth ? deps.resolveAuth(config) : null;
+  const titlePrefix = config.title;
   const questions = input.tool_input.questions;
   const answers = {};
 
@@ -146,7 +147,7 @@ export async function processAskUserQuestion(input, deps) {
       const sent = await sendWithRetry(deps.sendNotification, {
         server: config.ntfyServer,
         topic: config.topic,
-        title: `Claude Code: ${q.header || "Question"}`,
+        title: `${titlePrefix}: ${q.header || "Question"}`,
         message,
         actions,
         requestId,
@@ -217,7 +218,7 @@ export async function processHook(input, { loadConfig, sendNotification, waitFor
   }
 
   const requestId = crypto.randomUUID();
-  const { title, message } = formatToolInfo(input);
+  const { title, message } = formatToolInfo(input, { titlePrefix: config.title });
   const actions = buildActions(config.ntfyServer, config.topic, requestId, {
     permissionSuggestions: input.permission_suggestions,
     ...(auth && { auth }),

--- a/src/ntfy.mjs
+++ b/src/ntfy.mjs
@@ -446,18 +446,20 @@ function stripInline(text) {
  * Format tool information for display in the notification.
  *
  * @param {{ hook_event_name: string, tool_name: string, tool_input: Record<string, unknown> }} params
+ * @param {{ titlePrefix: string }} [options]
  * @returns {{ title: string, message: string }}
  */
-export function formatToolInfo({ hook_event_name, tool_name, tool_input }) {
+export function formatToolInfo({ hook_event_name, tool_name, tool_input }, { titlePrefix } = {}) {
+  const prefix = titlePrefix ?? 'Claude Code';
   let title;
   let message;
 
   if (tool_name === 'ExitPlanMode' && typeof tool_input?.plan === 'string') {
-    title = 'Claude Code: Plan Review';
+    title = `${prefix}: Plan Review`;
     const plain = tool_input.plan.trim() ? stripMarkdown(tool_input.plan) : '';
     message = plain || '(empty plan)';
   } else {
-    title = `Claude Code: ${tool_name}`;
+    title = `${prefix}: ${tool_name}`;
     switch (tool_name) {
       case 'Bash':
         message = tool_input?.command ?? JSON.stringify(tool_input);

--- a/test/config.test.mjs
+++ b/test/config.test.mjs
@@ -91,6 +91,10 @@ describe("DEFAULT_CONFIG", () => {
   it("should have ntfyPassword as empty string", () => {
     assert.equal(DEFAULT_CONFIG.ntfyPassword, "");
   });
+
+  it("should have title as 'Claude Code'", () => {
+    assert.equal(DEFAULT_CONFIG.title, "Claude Code");
+  });
 });
 
 // ==================== loadConfig ====================
@@ -127,6 +131,7 @@ describe("loadConfig", () => {
       autoDeny: [],
       ntfyUsername: "",
       ntfyPassword: "",
+      title: "Claude Code",
     });
   });
 
@@ -156,6 +161,7 @@ describe("loadConfig", () => {
       autoDeny: ["mcp__*"],
       ntfyUsername: "",
       ntfyPassword: "",
+      title: "My Claude",
     };
     fs.writeFileSync(tmpConfigPath, JSON.stringify(fullConfig, null, 2));
 
@@ -236,6 +242,24 @@ describe("loadConfig", () => {
     const config = loadConfig(tmpConfigPath);
     assert.equal(config.ntfyPassword, DEFAULT_CONFIG.ntfyPassword);
   });
+
+  it("should fall back to default title when title is not a string", () => {
+    fs.writeFileSync(tmpConfigPath, JSON.stringify({ title: 42 }));
+    const config = loadConfig(tmpConfigPath);
+    assert.equal(config.title, DEFAULT_CONFIG.title);
+  });
+
+  it("should fall back to default title when title is empty string", () => {
+    fs.writeFileSync(tmpConfigPath, JSON.stringify({ title: "" }));
+    const config = loadConfig(tmpConfigPath);
+    assert.equal(config.title, DEFAULT_CONFIG.title);
+  });
+
+  it("should accept a custom title string", () => {
+    fs.writeFileSync(tmpConfigPath, JSON.stringify({ title: "My Claude" }));
+    const config = loadConfig(tmpConfigPath);
+    assert.equal(config.title, "My Claude");
+  });
 });
 
 // ==================== saveConfig ====================
@@ -293,6 +317,7 @@ describe("saveConfig", () => {
       autoDeny: ["Bash(rm*)"],
       ntfyUsername: "",
       ntfyPassword: "",
+      title: "Claude Code",
     };
 
     saveConfig(original, tmpConfigPath);

--- a/test/ntfy.test.mjs
+++ b/test/ntfy.test.mjs
@@ -1030,6 +1030,41 @@ describe("formatToolInfo", () => {
     assert.equal(result.title, "Claude Code: Plan Review");
     assert.equal(result.message, "(empty plan)");
   });
+
+  // ==================== Custom titlePrefix ====================
+
+  it("should use custom titlePrefix for tool notifications", () => {
+    const result = formatToolInfo(
+      { hook_event_name: "PreToolUse", tool_name: "Bash", tool_input: { command: "ls" } },
+      { titlePrefix: "My Claude" },
+    );
+    assert.equal(result.title, "My Claude: Bash");
+  });
+
+  it("should use custom titlePrefix for plan review notifications", () => {
+    const result = formatToolInfo(
+      { hook_event_name: "PermissionRequest", tool_name: "ExitPlanMode", tool_input: { plan: "do stuff" } },
+      { titlePrefix: "Work PC" },
+    );
+    assert.equal(result.title, "Work PC: Plan Review");
+  });
+
+  it("should fall back to 'Claude Code' when titlePrefix is not provided", () => {
+    const result = formatToolInfo({
+      hook_event_name: "PreToolUse",
+      tool_name: "Read",
+      tool_input: { file_path: "/tmp/test" },
+    });
+    assert.equal(result.title, "Claude Code: Read");
+  });
+
+  it("should use empty titlePrefix literally when explicitly passed", () => {
+    const result = formatToolInfo(
+      { hook_event_name: "PreToolUse", tool_name: "Write", tool_input: { file_path: "/tmp/x" } },
+      { titlePrefix: "" },
+    );
+    assert.equal(result.title, ": Write");
+  });
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
This change adds support for customizing the prefix in titles that is originally hard-coded to "Claude Code". Useful when running Claude on multiple machines to distinguish where notifications comes from.