### PR TITLE
Add clear:true to action buttons so notifications dismiss on tap

### DIFF
--- a/src/hook.mjs
+++ b/src/hook.mjs
@@ -31,6 +31,7 @@ export function buildActions(server, topic, requestId, { permissionSuggestions, 
       url,
       body: JSON.stringify({ requestId, approved: true }),
       method: "POST",
+      clear: true,
       ...(authHeaders && { headers: authHeaders }),
     },
     {
@@ -39,6 +40,7 @@ export function buildActions(server, topic, requestId, { permissionSuggestions, 
       url,
       body: JSON.stringify({ requestId, approved: false }),
       method: "POST",
+      clear: true,
       ...(authHeaders && { headers: authHeaders }),
     },
   ];
@@ -49,6 +51,7 @@ export function buildActions(server, topic, requestId, { permissionSuggestions, 
       url,
       body: JSON.stringify({ requestId, approved: true, alwaysAllow: true }),
       method: "POST",
+      clear: true,
       ...(authHeaders && { headers: authHeaders }),
     });
   }
@@ -97,6 +100,7 @@ export function buildQuestionActions(server, topic, requestId, options, { auth }
     url,
     body: JSON.stringify({ requestId, answer: opt.label }),
     method: "POST",
+    clear: true,
     ...(authHeaders && { headers: authHeaders }),
   }));
 }

--- a/test/hook.test.mjs
+++ b/test/hook.test.mjs
@@ -93,6 +93,16 @@ describe("buildActions", () => {
     assert.equal(actions[1].headers, undefined);
   });
 
+  it("should set clear:true on every action so iOS dismisses the notification on tap", () => {
+    const actions = buildActions("https://ntfy.sh", "my-topic", "req-006c", {
+      permissionSuggestions: [{ type: "toolAlwaysAllow", tool: "Bash" }],
+    });
+    assert.equal(actions.length, 3);
+    for (const a of actions) {
+      assert.equal(a.clear, true, `${a.label} action should have clear:true`);
+    }
+  });
+
   it("should include requestId and approved:true in Approve body", () => {
     const actions = buildActions("https://ntfy.sh", "my-topic", "req-007");
 
@@ -1021,6 +1031,17 @@ describe("buildQuestionActions", () => {
     const actions = buildQuestionActions("https://ntfy.sh", "my-topic", "req-1", options);
 
     assert.equal(actions[0].url, "https://ntfy.sh/my-topic-response");
+  });
+
+  it("should set clear:true on every action so iOS dismisses the notification on tap", () => {
+    const options = [
+      { label: "Yes", description: "" },
+      { label: "No", description: "" },
+    ];
+    const actions = buildQuestionActions("https://ntfy.sh", "topic", "req-1", options);
+    for (const a of actions) {
+      assert.equal(a.clear, true, `${a.label} action should have clear:true`);
+    }
   });
 
   // ==================== Auth (Basic Auth headers) ====================


### PR DESCRIPTION
## Problem

ntfy's HTTP action buttons stay on the lock screen after the user taps them, because the action objects don't set [`clear: true`](https://docs.ntfy.sh/publish/#action-buttons). On iOS in particular this leaves the user unsure whether their **Approve** / **Deny** tap actually registered — the HTTP POST has fired in the background, but the notification is still sitting there exactly as before, with no visual change.

In practice this means:

- Users tap Approve, see nothing happen, and tap again — sometimes hitting Deny by accident.
- Stale prompts pile up on the lock screen even after the corresponding Claude Code request has long resolved.
- The "Always Approve" path is especially confusing because it looks identical to a no-op.

## Change

Set `clear: true` on every action emitted by:

- `buildActions` — Approve / Deny / Always Approve
- `buildQuestionActions` — per-option buttons for `AskUserQuestion`

This is the documented ntfy mechanism for "dismiss the notification when this button is tapped" and is supported on both the Android and iOS apps.

## Behavior change

| Before | After |
| --- | --- |
| Notification persists after tap; no visual feedback | Notification disappears immediately when the HTTP request leaves the device |

The actual Approve/Deny semantics are unchanged — only the surviving notification's lifecycle is affected.

## Tests

Added two assertions in `test/hook.test.mjs`:

- `buildActions … should set clear:true on every action so iOS dismisses the notification on tap` (covers Approve / Always Approve / Deny)
- `buildQuestionActions … should set clear:true on every action so iOS dismisses the notification on tap`

Full suite: 274 pass / 1 fail. The single failure is `test/cli.test.mjs` and is **pre-existing on `main`** — not introduced by this change.

## Verified manually

Patched a local install on macOS + iOS ntfy app pointing at a self-hosted ntfy server (with `upstream-base-url: https://ntfy.sh` for iOS push). Approve and Deny now dismiss the lock-screen notification within ~1s of the tap, while the hook still receives the response and exits with the correct decision JSON.